### PR TITLE
Fix compilation of libswipl.cc by using the right type

### DIFF
--- a/src/libswipl.cc
+++ b/src/libswipl.cc
@@ -80,7 +80,7 @@ Local<Value> ExportCompound(term_t t) {
     }
     name = PL_atom_chars(n);
     Local<Array> args = New<Array>();
-    for (int i = 1; i <= arity; ++i) {
+    for (size_t i = 1; i <= arity; ++i) {
         term_t arg_t = PL_new_term_ref();
         if (!PL_get_arg(i, t, arg_t)) {
             ThrowError("PL_get_arg failed.");

--- a/src/libswipl.cc
+++ b/src/libswipl.cc
@@ -72,7 +72,7 @@ Local<Value> ExportTermValue(term_t t);
 Local<Value> ExportCompound(term_t t) {
     Local<Object> compound = New<Object>();
     atom_t n;
-    int arity;
+    size_t arity;
     const char *name;
     if (!PL_get_compound_name_arity(t, &n, &arity)) {
         ThrowError("PL_get_compound_name_arity failed.");


### PR DESCRIPTION
Trying to `npm install swipl` on my Ubuntu 20.04.3 LTS failed with below error.

```
npm ERR! ../src/libswipl.cc:77:44: error: cannot convert 'int*' to 'size_t*' {aka 'long unsigned int*'}
npm ERR!    77 |     if (!PL_get_compound_name_arity(t, &n, &arity)) {
npm ERR!       |                                            ^~~~~~
npm ERR!       |                                            |
npm ERR!       |                                            int*
```

This fixes it.